### PR TITLE
Small type checking

### DIFF
--- a/index.js
+++ b/index.js
@@ -308,13 +308,14 @@ async function run() {
         throw new Error(`Service is ${serviceResponse.status}`);
       }
 
-      if (!serviceResponse.deploymentController || serviceResponse.deploymentController.type === "ECS") {
+      if (!serviceResponse.deploymentController || (serviceResponse.deploymentController && serviceResponse.deploymentController.type === "ECS")) {
         // Service uses the 'ECS' deployment controller, so we can call UpdateService
         await updateEcsService(ecs, clusterName, service, taskDefArn, waitForService, waitForMinutes, forceNewDeployment);
       } else if (serviceResponse.deploymentController.type === 'CODE_DEPLOY') {
         // Service uses CodeDeploy, so we should start a CodeDeploy deployment
         await createCodeDeployDeployment(codedeploy, clusterName, service, taskDefArn, waitForService, waitForMinutes);
       } else {
+        core.debug(`Service uses unsupported deployment controller type: ${serviceResponse.deploymentController.type || serviceResponse.deploymentController}`);
         throw new Error(`Unsupported deployment controller: ${serviceResponse.deploymentController.type}`);
       }
     } else {


### PR DESCRIPTION
*Issue #, if available:*

If the `serviceResponse.deploymentController` object is missing in its entirety, the OR operation will fail to be able to check for `.type` at all.

*Description of changes:*

I found that this is a relatively strange value in the ECS Service definition itself and I'm not sure why sometimes it is there and sometimes it is not - our team uses Cloudformation templates for our services and none of which have been updated with these values so some services return no `deploymentController` object whatsoever and others return it as `{ "type": "ECS" }` (or whatever).

You can check your service with this command:

```shell
aws ecs describe-services --cluster <YOUR_CLUSTER_ARN> --services <YOUR_SERVICE_NAME(S)>
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
